### PR TITLE
Fixes the 'space case' example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ $ npm install to-snake-case
 var toSnakeCase = require('to-snake-case')
 
 toSnakeCase('camelCase')   // "camel_case"
-toSnakeCase('space case')  // "snake_case"
+toSnakeCase('space case')  // "space_case"
 toSnakeCase('dot.case')    // "dot_case"
 toSnakeCase('weird[case')  // "weird_case"
 ```


### PR DESCRIPTION
It was suggesting that the 'space' word would be replaced by 'snake', which is not true.